### PR TITLE
Expose the port the service runs on

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,5 @@ RUN cd /var/www/readthedocs.org/readthedocs \
 RUN pip install supervisor
 ADD files/supervisord.conf /etc/supervisord.conf
 
+EXPOSE 8000
 CMD ["supervisord"]


### PR DESCRIPTION
We need this because of the bug bmatt pointed out earlier about salt states not supporting the expose attribute
