### PR TITLE
OPS-1710 setup updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM python:2.7
-
+FROM library/python:2.7
 MAINTAINER Lucid Operations "http://github.com/luciddg"
 
 # install readthedocs
+ENV rtd_home /var/www/readthedocs.org
 RUN mkdir /var/www \
-  && git clone https://github.com/rtfd/readthedocs.org.git /var/www/readthedocs.org
-RUN pip install -r /var/www/readthedocs.org/requirements.txt
-RUN /var/www/readthedocs.org/manage.py syncdb --noinput \
-  && /var/www/readthedocs.org/manage.py makemigrations \
-  && /var/www/readthedocs.org/manage.py migrate
+  && git clone https://github.com/rtfd/readthedocs.org.git ${rtd_home}
+WORKDIR ${rtd_home}
+RUN pip install -r requirements.txt
+RUN ./manage.py syncdb --noinput \
+  && ./manage.py makemigrations \
+  && ./manage.py migrate
 
-# install uwsgi and supervisord
-RUN pip install supervisor
-ADD files/supervisord.conf /etc/supervisord.conf
+# install uwsgi
+RUN pip install uwsgi
 
 EXPOSE 8000
-CMD ["supervisord"]
+CMD ["./manage.py", "print_settings"]

--- a/README.md
+++ b/README.md
@@ -1,17 +1,60 @@
 Dockerfile for ReadTheDocs
 ==========================
 
-This project provides a Dockerfile for building a self-hosted 
+This project provides a Dockerfile for building a self-hosted
 [readthedocs](http://readthedocs.org) instance.
 
 Features
 --------
 
-Uses a base of the `python:2.7` image and the latest pull from 
-[github](https://github.com/rtfd/readthedocs.org).  It currently uses the
-built-in Django webserver.
+Based on the official [`library/python:2.7`](https://github.com/docker-library/python/blob/15798abb6cfb145344462a345db4b572227fb859/2.7/Dockerfile)
+image from the [Docker Hub](https://hub.docker.com/_/python/) and the latest
+pull from [github](https://github.com/rtfd/readthedocs.org). The image currently
+includes the [uWSGI](http://uwsgi-docs.readthedocs.org) application server and
+a sample NGiNX [configuration](files/nginx.conf) file as an example of how one
+might run a production-like setup. To drive this example a little further, we
+have provided a [`docker-compose`](docker-compose.yml) configuration with some
+defaults.
 
 Usage
 -----
 
-   docker run -d --name readthedocs -p 8000:8000 registry.luciddg.com/luciddg/readthedocs
+Using the built in Django webserver
+
+```shell
+$ docker run -d --name readthedocs \
+    -p 8000:8000 \
+    luciddg/readthedocs \
+    ./manage.py runserver
+```
+
+Using the uWSGI HTTP server/router
+
+```shell
+$ docker run -d --name readthedocs \
+    -p 8000:8000 \
+    luciddg/readthedocs \
+    uwsgi --http :8000 --module readthedocs.wsgi --env DJANGO_SETTINGS_MODULE=readthedocs.settings.sqlite
+```
+
+If you choose to run it behind a fully capable webserver such as NGiNX, you
+may choose to configure your container to speak the uwsgi protocol natively.
+This is basically the same as above, but with the `--socket` switch in place of
+`--http`. In this case, you will most likely link this container to an NGiNX
+container, so there is no need to proxy the exposed port externally.
+
+```shell
+$ docker run -d --name readthedocs luciddg/readthedocs \
+    uwsgi --socket 0.0.0.0:8000 --module readthedocs.wsgi --env DJANGO_SETTINGS_MODULE=readthedocs.settings.sqlite
+$ docker run -d --name nginx-proxy  \
+    -v ${PWD}/files/nginx.conf:/etc/nginx/conf.d/default.conf:ro \
+    --link readthedocs:rtd \
+    -p 80:80 \
+    library/nginx
+```
+
+The same result may be accomplished with the provided `docker-compose.yml` for
+convenience. The uWSGI settings provided as command line arguments above are
+provided as environment variables in our `docker-compose.yml`
+
+    $ docker-compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+rtd-service:
+  build: .
+  container_name: 'rtd-999-99-service'
+  restart: 'always'
+  command: 'uwsgi'
+  environment:
+      UWSGI_SOCKET: '0.0.0.0:8000'
+      UWSGI_MODULE: 'readthedocs.wsgi'
+      UWSGI_ENV: 'DJANGO_SETTINGS_MODULE=readthedocs.settings.sqlite'
+nginx-proxy:
+  image: 'library/nginx:1.9.0'
+  container_name: 'nginx-999-99-proxy'
+  restart: 'always'
+  volumes:
+    - './files/nginx.conf:/etc/nginx/conf.d/default.conf:ro'
+  links:
+    - 'rtd-service:rtd'
+  ports:
+    - '80:80'

--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -1,0 +1,10 @@
+upstream rtd {
+  server rtd:8000;
+}
+server {
+  listen 80;
+  location / {
+    uwsgi_pass rtd;
+    include    /etc/nginx/uwsgi_params;
+  }
+}

--- a/files/supervisord.conf
+++ b/files/supervisord.conf
@@ -1,9 +1,0 @@
-[supervisord]
-nodaemon=true
-
-[program:readthedocs]
-directory=/var/www/readthedocs.org
-command=python manage.py runserver 0.0.0.0:8000
-autostart=true
-autorestart=true
-

--- a/files/supervisord.conf
+++ b/files/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:readthedocs]
-directory=/var/www/readthedocs.org/readthedocs
+directory=/var/www/readthedocs.org
 command=python manage.py runserver 0.0.0.0:8000
 autostart=true
 autorestart=true


### PR DESCRIPTION
This replaces the supervisor installation in the base image with uwsgi. The default command for containers based on this image is to print the Django settings. 

This adds a sample nginx config for talking uwsgi protocol natively and a docker-compose file for easily standing up the pair for testing.

Documentation has been updated to reflect a few ways to use this image for useful service containers.
